### PR TITLE
resolve issues mgr-restful-plugin scripts

### DIFF
--- a/ceph/ceph/files/mgr-restful-plugin
+++ b/ceph/ceph/files/mgr-restful-plugin
@@ -17,7 +17,7 @@ DESC="mgr-restful-plugin"
 DAEMON="/usr/bin/ceph-mgr"
 RUNDIR="/var/run/ceph/mgr"
 # KEEP PIDFILE to be tracked by SM: https://review.openstack.org/#/c/634120
-PIDFILE="${RUNDIR}/../mgr-restful-plugin.pid"
+PIDFILE="${RUNDIR}/mgr-restful-plugin.pid"
 user_name=`hostname`
 MGR_ARGS="-f --cluster ceph --id ${user_name}"
 # The default 8003 port is already used by StarlingX "lsof -i :8003"
@@ -133,10 +133,9 @@ start_restful_plugin()
 
     #ceph config set mgr mgr/restful/${user_name}/server_port $PORT
     ceph config set mgr mgr/restful/server_port $PORT
-    ceph restful create-self-signed-cert
     ceph restful create-key admin
+    ceph restful create-self-signed-cert
 #    ceph mgr module enable restful
-    ceph restful restart
     restful_check
     rst=$?
     if [ $rst -eq 0 ]; then

--- a/ceph/ceph/files/mgr-restful-plugin.service
+++ b/ceph/ceph/files/mgr-restful-plugin.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ceph MGR RESTful API Plugin
-After=network.target ceph.target
+After=network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
1. in mgr-restful-plugin, PID path doesn't match with the path
   specified in "./sm-db-1.0.0/database/create_sm_db.sql".
2. in mgr-restful-plugin, remove duplicated "restart"
3. in in mgr-restful-plugin.service, get rid of the dependency
   on ceph.service/target, which is not available in system

Signed-off-by: Yong Hu <yong.hu@intel.com>